### PR TITLE
Add critnib_emplace method.

### DIFF
--- a/critnib.h
+++ b/critnib.h
@@ -21,10 +21,13 @@ enum find_dir_t {
 	FIND_G  = +2,
 };
 
+typedef void* critnib_constr(int exists, void *old_data, void *arg);
+
 critnib *critnib_new(void);
 void critnib_delete(critnib *c);
 
 int critnib_insert(critnib *c, uintptr_t key, void *value, int update);
+int critnib_emplace(critnib *c, uintptr_t key, critnib_constr constr, void *arg);
 void *critnib_remove(critnib *c, uintptr_t key);
 void *critnib_get(critnib *c, uintptr_t key);
 void *critnib_find_le(critnib *c, uintptr_t key);

--- a/critnib.h
+++ b/critnib.h
@@ -21,7 +21,7 @@ enum find_dir_t {
 	FIND_G  = +2,
 };
 
-typedef void* critnib_constr(int exists, void *old_data, void *arg);
+typedef int critnib_constr(int exists, void **data, void *arg);
 
 critnib *critnib_new(void);
 void critnib_delete(critnib *c);

--- a/libcritnib.pod
+++ b/libcritnib.pod
@@ -27,9 +27,9 @@ have their memory freed until this function is called.
 
 =item B<int critnib_insert(critnib *>I<c>B<, uintptr_t >I<key>B<, void *>I<value>B<, int >I<update>B<);>
 
-Adds a key:value pair to the critnib structure.  value is calculated as result
-of critnib_constr(int exists, void *old_data, void *arg). It may return
-B<ENOMEM> if we're out of memory, or 0 if all went okay.
+Adds a key:value pair to the critnib structure. Value is obtained by calling constr(existed, &value, arg).
+It may return B<ENOMEM> if we're out of memory, or result of constr() otherwise. If return value is non-zero,
+the element was not added.
 
 =item B<int critnib_emplace(critnib *>I<c>B<, uintptr_t >I<key>B<, critnib_constr >I<constr>B<, void >I<*arg>B<);>
 

--- a/libcritnib.pod
+++ b/libcritnib.pod
@@ -27,6 +27,12 @@ have their memory freed until this function is called.
 
 =item B<int critnib_insert(critnib *>I<c>B<, uintptr_t >I<key>B<, void *>I<value>B<, int >I<update>B<);>
 
+Adds a key:value pair to the critnib structure.  value is calculated as result
+of critnib_constr(int exists, void *old_data, void *arg). It may return
+B<ENOMEM> if we're out of memory, or 0 if all went okay.
+
+=item B<int critnib_emplace(critnib *>I<c>B<, uintptr_t >I<key>B<, critnib_constr >I<constr>B<, void >I<*arg>B<);>
+
 Adds a key:value pair to the critnib structure.  If I<update> is non-zero,
 an already existing key has its value updated, otherwise the function returns
 B<EEXIST>.  It may return B<ENOMEM> if we're out of memory, or 0 if all went

--- a/tests/hmload.c
+++ b/tests/hmload.c
@@ -14,6 +14,7 @@ void hm_select(int i)
 {
     hm_new	= hms[i].hm_new;
     hm_delete	= hms[i].hm_delete;
+    hm_emplace  = hms[i].hm_emplace;
     hm_insert	= hms[i].hm_insert;
     hm_remove	= hms[i].hm_remove;
     hm_get	= hms[i].hm_get;

--- a/tests/hmproto.h
+++ b/tests/hmproto.h
@@ -8,7 +8,7 @@ enum find_dir_t {
 	FIND_G  = +2,
 };
 
-typedef void* constr_f(int exists, void *old_data, void *arg);
+typedef int constr_f(int exists, void **data, void *arg);
 
 #define HM_PROTOS(x) \
     void *x##_new(void);\

--- a/tests/hmproto.h
+++ b/tests/hmproto.h
@@ -8,10 +8,13 @@ enum find_dir_t {
 	FIND_G  = +2,
 };
 
+typedef void* constr_f(int exists, void *old_data, void *arg);
+
 #define HM_PROTOS(x) \
     void *x##_new(void);\
     void x##_delete(void *c);\
     \
+    int x##_emplace(void *c, uintptr_t key, constr_f constr, void *arg);\
     int x##_insert(void *c, uintptr_t key, void *value, int update);\
     void *x##_remove(void *c, uintptr_t key);\
     void *x##_get(void *c, uintptr_t key);\
@@ -25,6 +28,7 @@ HM_PROTOS(critnib)
 
 void *(*hm_new)(void);
 void (*hm_delete)(void *c);
+int (*hm_emplace)(void *c, uintptr_t key, constr_f constr, void *arg);
 int (*hm_insert)(void *c, uintptr_t key, void *value, int update);
 void *(*hm_remove)(void *c, uintptr_t key);
 void *(*hm_get)(void *c, uintptr_t key);
@@ -37,6 +41,7 @@ int hm_immutable;
 #define HM_SELECT(x) \
     HM_SELECT_ONE(x,new);\
     HM_SELECT_ONE(x,delete);\
+    HM_SELECT_ONE(x,emplace);\
     HM_SELECT_ONE(x,insert);\
     HM_SELECT_ONE(x,remove);\
     HM_SELECT_ONE(x,get);\
@@ -44,12 +49,14 @@ int hm_immutable;
     HM_SELECT_ONE(x,find);\
     hm_name=#x
 
-#define HM_ARR(x,imm) { x##_new, x##_delete, x##_insert, x##_remove, x##_get, \
-                        x##_find_le, x##_find, #x, imm }
+#define HM_ARR(x,imm) { x##_new, x##_delete, x##_emplace, x##_insert, \
+                        x##_remove, x##_get, x##_find_le, x##_find, #x, \
+                        imm }
 struct hm
 {
     void *(*hm_new)(void);
     void (*hm_delete)(void *c);
+    int (*hm_emplace)(void *c, uintptr_t key, constr_f constr, void *arg);
     int (*hm_insert)(void *c, uintptr_t key, void *value, int update);
     void *(*hm_remove)(void *c, uintptr_t key);
     void *(*hm_get)(void *c, uintptr_t key);


### PR DESCRIPTION
I have two use cases for this method:
1. Calculate value to be inserted lazily.
   This is useful for case where multiple threads are trying
   to insert result of some costly computation to critnib. With
   emplace, only one of them can do the work while other will wait
   on lock.
2. If element already exists in critnib we can return pointer to it
   via *arg. This avoids calling get after insert.